### PR TITLE
fix: process exit listener causing memory leak

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export class RspackVirtualModulePlugin implements RspackPluginInstance {
         {} as Record<string, string>,
       ),
     };
-    compiler.hooks.done.tap('RspackVirtualModulePlugin', () => {
+    compiler.hooks.shutdown.tap('RspackVirtualModulePlugin', () => {
       this.clear.bind(this);
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,71 +1,127 @@
 import crypto from 'node:crypto';
-import path, { dirname, join, extname } from 'node:path';
+import path, { dirname, extname, join } from 'node:path';
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 import fs from 'fs-extra';
 
 export class RspackVirtualModulePlugin implements RspackPluginInstance {
   #staticModules: Record<string, string>;
-
   #tempDir: string;
+  #cleanupHandler: (() => void) | null = null;
+  #isWatching = false;
 
   constructor(staticModules: Record<string, string>, tempDir?: string) {
     this.#staticModules = staticModules;
-    const nodeModulesDir = join(process.cwd(), 'node_modules');
-    if (!fs.existsSync(nodeModulesDir)) {
-      fs.mkdirSync(nodeModulesDir);
-    }
 
-    if (!tempDir) {
-      const hash = crypto
-        .createHash('md5')
-        .update(JSON.stringify(this.#staticModules))
-        .digest('hex')
-        .slice(0, 8);
-      this.#tempDir = path.join(
-        nodeModulesDir,
-        `rspack-virtual-module-${hash}`,
+    try {
+      const nodeModulesDir = join(process.cwd(), 'node_modules');
+      fs.ensureDirSync(nodeModulesDir);
+
+      if (!tempDir) {
+        const hash = crypto
+          .createHash('md5')
+          .update(JSON.stringify(this.#staticModules))
+          .digest('hex')
+          .slice(0, 8);
+        this.#tempDir = path.join(
+          nodeModulesDir,
+          `rspack-virtual-module-${hash}`,
+        );
+      } else {
+        this.#tempDir = path.join(nodeModulesDir, tempDir);
+      }
+
+      fs.ensureDirSync(this.#tempDir);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to initialize virtual module plugin: ${errorMessage}`,
       );
-    } else {
-      this.#tempDir = path.join(nodeModulesDir, tempDir);
-    }
-    if (!fs.existsSync(this.#tempDir)) {
-      fs.mkdirSync(this.#tempDir);
     }
   }
 
   apply(compiler: Compiler) {
-    // Write the modules to the disk
-    for (const [path, content] of Object.entries(this.#staticModules)) {
-      this.writeModule(path, content);
+    try {
+      // Write the modules to the disk
+      for (const [path, content] of Object.entries(this.#staticModules)) {
+        this.writeModule(path, content);
+      }
+
+      const originalResolveModulesDir = compiler.options.resolve.modules || [
+        'node_modules',
+      ];
+      compiler.options.resolve.modules = [
+        ...originalResolveModulesDir,
+        this.#tempDir,
+      ];
+      compiler.options.resolve.alias = {
+        ...compiler.options.resolve.alias,
+        ...Object.keys(this.#staticModules).reduce(
+          (acc, p) => {
+            acc[p] = this.#normalizePath(p);
+            return acc;
+          },
+          {} as Record<string, string>,
+        ),
+      };
+
+      const boundClear = this.clear.bind(this);
+      this.#cleanupHandler = boundClear;
+
+      compiler.hooks.shutdown.tap('RspackVirtualModulePlugin', boundClear);
+
+      compiler.hooks.watchRun.tap('RspackVirtualModulePlugin', () => {
+        this.#isWatching = true;
+      });
+
+      compiler.hooks.watchClose.tap('RspackVirtualModulePlugin', () => {
+        if (this.#isWatching) {
+          boundClear();
+          this.#isWatching = false;
+        }
+      });
+
+      compiler.hooks.done.tap('RspackVirtualModulePlugin', (stats) => {
+        if (stats.hasErrors() && !this.#isWatching) {
+          boundClear();
+        }
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(`RspackVirtualModulePlugin error: ${errorMessage}`);
     }
-    const originalResolveModulesDir = compiler.options.resolve.modules || [
-      'node_modules',
-    ];
-    compiler.options.resolve.modules = [
-      ...originalResolveModulesDir,
-      this.#tempDir,
-    ];
-    compiler.options.resolve.alias = {
-      ...compiler.options.resolve.alias,
-      ...Object.keys(this.#staticModules).reduce(
-        (acc, p) => {
-          acc[p] = this.#normalizePath(p);
-          return acc;
-        },
-        {} as Record<string, string>,
-      ),
-    };
-    process.on('exit', this.clear.bind(this));
   }
 
   writeModule(path: string, content: string) {
-    const normalizedPath = this.#normalizePath(path);
-    fs.ensureDirSync(dirname(normalizedPath));
-    fs.writeFileSync(normalizedPath, content);
+    try {
+      const normalizedPath = this.#normalizePath(path);
+      fs.ensureDirSync(dirname(normalizedPath));
+      if (fs.existsSync(normalizedPath)) {
+        const existingContent = fs.readFileSync(normalizedPath, 'utf8');
+        if (existingContent === content) {
+          return;
+        }
+      }
+
+      fs.writeFileSync(normalizedPath, content);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to write virtual module ${path}: ${errorMessage}`,
+      );
+    }
   }
 
   clear() {
-    fs.removeSync(this.#tempDir);
+    try {
+      if (fs.existsSync(this.#tempDir)) {
+        fs.removeSync(this.#tempDir);
+      }
+    } catch (error) {
+      console.warn(`Failed to clean up virtual modules: ${error}`);
+    }
   }
 
   #normalizePath(p: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,127 +1,73 @@
 import crypto from 'node:crypto';
-import path, { dirname, extname, join } from 'node:path';
+import path, { dirname, join, extname } from 'node:path';
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 import fs from 'fs-extra';
 
 export class RspackVirtualModulePlugin implements RspackPluginInstance {
   #staticModules: Record<string, string>;
+
   #tempDir: string;
-  #cleanupHandler: (() => void) | null = null;
-  #isWatching = false;
 
   constructor(staticModules: Record<string, string>, tempDir?: string) {
     this.#staticModules = staticModules;
+    const nodeModulesDir = join(process.cwd(), 'node_modules');
+    if (!fs.existsSync(nodeModulesDir)) {
+      fs.mkdirSync(nodeModulesDir);
+    }
 
-    try {
-      const nodeModulesDir = join(process.cwd(), 'node_modules');
-      fs.ensureDirSync(nodeModulesDir);
-
-      if (!tempDir) {
-        const hash = crypto
-          .createHash('md5')
-          .update(JSON.stringify(this.#staticModules))
-          .digest('hex')
-          .slice(0, 8);
-        this.#tempDir = path.join(
-          nodeModulesDir,
-          `rspack-virtual-module-${hash}`,
-        );
-      } else {
-        this.#tempDir = path.join(nodeModulesDir, tempDir);
-      }
-
-      fs.ensureDirSync(this.#tempDir);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      throw new Error(
-        `Failed to initialize virtual module plugin: ${errorMessage}`,
+    if (!tempDir) {
+      const hash = crypto
+        .createHash('md5')
+        .update(JSON.stringify(this.#staticModules))
+        .digest('hex')
+        .slice(0, 8);
+      this.#tempDir = path.join(
+        nodeModulesDir,
+        `rspack-virtual-module-${hash}`,
       );
+    } else {
+      this.#tempDir = path.join(nodeModulesDir, tempDir);
+    }
+    if (!fs.existsSync(this.#tempDir)) {
+      fs.mkdirSync(this.#tempDir);
     }
   }
 
   apply(compiler: Compiler) {
-    try {
-      // Write the modules to the disk
-      for (const [path, content] of Object.entries(this.#staticModules)) {
-        this.writeModule(path, content);
-      }
-
-      const originalResolveModulesDir = compiler.options.resolve.modules || [
-        'node_modules',
-      ];
-      compiler.options.resolve.modules = [
-        ...originalResolveModulesDir,
-        this.#tempDir,
-      ];
-      compiler.options.resolve.alias = {
-        ...compiler.options.resolve.alias,
-        ...Object.keys(this.#staticModules).reduce(
-          (acc, p) => {
-            acc[p] = this.#normalizePath(p);
-            return acc;
-          },
-          {} as Record<string, string>,
-        ),
-      };
-
-      const boundClear = this.clear.bind(this);
-      this.#cleanupHandler = boundClear;
-
-      compiler.hooks.shutdown.tap('RspackVirtualModulePlugin', boundClear);
-
-      compiler.hooks.watchRun.tap('RspackVirtualModulePlugin', () => {
-        this.#isWatching = true;
-      });
-
-      compiler.hooks.watchClose.tap('RspackVirtualModulePlugin', () => {
-        if (this.#isWatching) {
-          boundClear();
-          this.#isWatching = false;
-        }
-      });
-
-      compiler.hooks.done.tap('RspackVirtualModulePlugin', (stats) => {
-        if (stats.hasErrors() && !this.#isWatching) {
-          boundClear();
-        }
-      });
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      throw new Error(`RspackVirtualModulePlugin error: ${errorMessage}`);
+    // Write the modules to the disk
+    for (const [path, content] of Object.entries(this.#staticModules)) {
+      this.writeModule(path, content);
     }
+    const originalResolveModulesDir = compiler.options.resolve.modules || [
+      'node_modules',
+    ];
+    compiler.options.resolve.modules = [
+      ...originalResolveModulesDir,
+      this.#tempDir,
+    ];
+    compiler.options.resolve.alias = {
+      ...compiler.options.resolve.alias,
+      ...Object.keys(this.#staticModules).reduce(
+        (acc, p) => {
+          acc[p] = this.#normalizePath(p);
+          return acc;
+        },
+        {} as Record<string, string>,
+      ),
+    };
+    compiler.hooks.done.tap('RspackVirtualModulePlugin', () => {
+      this.clear.bind(this);
+    });
   }
 
   writeModule(path: string, content: string) {
-    try {
-      const normalizedPath = this.#normalizePath(path);
-      fs.ensureDirSync(dirname(normalizedPath));
-      if (fs.existsSync(normalizedPath)) {
-        const existingContent = fs.readFileSync(normalizedPath, 'utf8');
-        if (existingContent === content) {
-          return;
-        }
-      }
-
-      fs.writeFileSync(normalizedPath, content);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      throw new Error(
-        `Failed to write virtual module ${path}: ${errorMessage}`,
-      );
-    }
+    const normalizedPath = this.#normalizePath(path);
+    fs.ensureDirSync(dirname(normalizedPath));
+    fs.writeFileSync(normalizedPath, content);
   }
 
   clear() {
-    try {
-      if (fs.existsSync(this.#tempDir)) {
-        fs.removeSync(this.#tempDir);
-      }
-    } catch (error) {
-      console.warn(`Failed to clean up virtual modules: ${error}`);
-    }
+    fs.removeSync(this.#tempDir);
   }
 
   #normalizePath(p: string) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/46c5c744-b7a4-4a98-a80c-e8e1bc0b06f5)

当 [rspack-plugin-virtual-module](https://github.com/rspack-contrib/rspack-plugin-virtual-module) 虚拟模块使用的比较多的时候，会引发内存泄露问题。