### PR TITLE
fix: should call clear method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export class RspackVirtualModulePlugin implements RspackPluginInstance {
       ),
     };
     compiler.hooks.shutdown.tap('RspackVirtualModulePlugin', () => {
-      this.clear.bind(this);
+      this.clear();
     });
   }
 


### PR DESCRIPTION
The change ensures the `clear` method is correctly invoked during the `shutdown` hook by replacing the `.bind(this)` call with a direct method invocation.

Related: https://github.com/rspack-contrib/rspack-plugin-virtual-module/pull/28